### PR TITLE
Add deviceId as an message input parameter

### DIFF
--- a/src/utils/ewelink-connect.js
+++ b/src/utils/ewelink-connect.js
@@ -64,8 +64,14 @@ module.exports = {
         const evaluatedMethod = method || msg.payload.method;
         const evaluatedParams = (typeof params === 'function' ? params(msg) : params) || msg.payload.params || [];
         
+        let device_id = '';
+        if (deviceId) {
+          device_id = deviceId;
+        } else if (typeof msg.deviceId !== "undefined") {
+          device_id = msg.deviceId || '';
+        }
         // First parameter should be always the device ID
-        evaluatedParams.unshift(deviceId);
+        evaluatedParams.unshift(device_id);
         
         // Call dynamically the method
         connection[evaluatedMethod].apply(connection, evaluatedParams).then(result => {


### PR DESCRIPTION
Hi,
first of all, thanks for your great job.
I'd like to specify the deviceId inside the message sent to the node and not always inside the node itself, like msg.deviceId= .....
It should is a simple fix, in ewelink-connect.js, just replaced the row:


        evaluatedParams.unshift(deviceId);
        // First parameter should be always the device ID


with following rows:


        let device_id = '';
        if (deviceId) {
          device_id = deviceId;
        } else if (typeof msg.deviceId !== "undefined") {
          device_id = msg.deviceId || '';
        }
        // First parameter should be always the device ID
        evaluatedParams.unshift(device_id);


In this way it the deviceId is not specified inside the node configuration, it will use the one specified inside the message.

Thanks
Claudio